### PR TITLE
Add UI feedback for enabled tracks.

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -58,6 +58,8 @@ input[type='range']::-webkit-slider-thumb {
 
 .sound_btn {
   cursor: pointer;
+  opacity: 0.4;
+  transition: all 0.4s;
 }
 
 .volume {

--- a/js/index.js
+++ b/js/index.js
@@ -73,7 +73,15 @@ $('.volume').change(function() {
 });
 
 $('.sound_btn').click(function() {
-  switch ($(this).attr("id")) {
+  let elem = $(this);
+
+  if (elem.css("opacity") < 1.0) {
+    elem.css("opacity", 1.0);
+  } else {
+    elem.css("opacity", 0.4);
+  }
+
+  switch (elem.attr("id")) {
     case "birds":
 
       if(birds.paused) {


### PR DESCRIPTION
Hi,

Just fiddling around. With several sounds enabled I lose track of which buttons I clicked earlier. This patch will highlight playing tracks.

Another solution would be a speaker icon next to each button, as I'm not sure how visible 0.4 opacity is on all screens.

Thanks.